### PR TITLE
Fixed fatal error in CI 2.1.3

### DIFF
--- a/libraries/ga_api.php
+++ b/libraries/ga_api.php
@@ -88,7 +88,7 @@ class Ga_api {
 		{
 			if (isset($this->$key)) $this->$key = $val;
 		}
-		if (isset($this->ci->config['clear_cache'])) $this->clear_cache($this->clear_cache);
+		if (isset($this->ci->config->clear_cache)) $this->clear_cache($this->clear_cache);
 	}
 
 	//---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixed 'Fatal error: Cannot use object of type CI_Config as array in /home/abcwin/applications/portal/libraries/ga_api.php on line 88'
